### PR TITLE
회원가입시 create,update 모두 들어가는 현상수정

### DIFF
--- a/src/main/java/com/sparta/bedelivery/config/JpaConfig.java
+++ b/src/main/java/com/sparta/bedelivery/config/JpaConfig.java
@@ -5,12 +5,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.domain.AuditorAware;
 
-@Configuration
-@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+//@Configuration
+//@EnableJpaAuditing(auditorAwareRef = "auditorAware")
 public class JpaConfig {
 
-    @Bean
-    public AuditorAware<String> auditorAware() {
-        return new com.sparta.bedelivery.config.UserAuditorAware();
-    }
+//    @Bean
+//    public AuditorAware<String> auditorAware() {
+//        return new com.sparta.bedelivery.config.UserAuditorAware();
+//    }
 }

--- a/src/main/java/com/sparta/bedelivery/entity/BaseSystemFieldEntity.java
+++ b/src/main/java/com/sparta/bedelivery/entity/BaseSystemFieldEntity.java
@@ -1,9 +1,6 @@
 package com.sparta.bedelivery.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PreUpdate;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -11,10 +8,13 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 
-@EntityListeners(AuditingEntityListener.class)
+//@EntityListeners(AuditingEntityListener.class) //UserAuditorAware 사용 삭제
 @MappedSuperclass
 @Getter
 @Setter
@@ -25,15 +25,15 @@ public abstract class BaseSystemFieldEntity {
     private LocalDateTime createAt;
 
     @CreatedBy
-    @Column(nullable = false)
+    @Column(updatable = false, nullable = false)
     private String createBy;
 
-    @UpdateTimestamp
-    @Column(nullable = false)
+//    @UpdateTimestamp
+    @Column(nullable = true)
     private LocalDateTime updateAt;
 
-    @LastModifiedBy
-    @Column(nullable = false)
+//    @LastModifiedBy
+    @Column(nullable = true)
     private String updateBy;
 
     @Column
@@ -42,14 +42,45 @@ public abstract class BaseSystemFieldEntity {
     @Column
     private String deleteBy;
 
+    // CREATE 시에는 updateAt과 updateBy를 설정하지 않음
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        if (createAt == null) {
+            createAt = now;
+        }
+        if (createBy == null) {
+            createBy =  getCurrentUsername();  // 실제 사용자 정보
+        }
+        updateAt = null;
+        updateBy = null;
+        // CREATE 시에는 updateAt과 updateBy를 설정하지 않음
+    }
+
+    // UPDATE 시에만 updateAt과 updateBy를 갱신
     @PreUpdate
     public void preUpdate() {
-        updateAt = LocalDateTime.now();
+        if (updateAt == null) {
+            updateAt = LocalDateTime.now();
+        }
+        if (updateBy == null) {
+            updateBy =  getCurrentUsername();  // 실제 사용자 정보
+        }
     }
     // 소프트 삭제 처리
     public void delete(String deletedBy) {
         this.deleteBy = deletedBy;
         this.deleteAt = LocalDateTime.now();
+    }
+
+    // 현재 인증된 사용자의 이름을 가져오는 메서드
+    private String getCurrentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails) {
+            UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+            return userDetails.getUsername();  // 로그인한 사용자의 이름 반환
+        }
+        return "anonymousUser";  // 인증되지 않은 경우 'anonymous' 반환
     }
 
 }

--- a/src/main/java/com/sparta/bedelivery/entity/User.java
+++ b/src/main/java/com/sparta/bedelivery/entity/User.java
@@ -55,6 +55,7 @@ public class User extends BaseSystemFieldEntity {
         this.name = request.getName();
         this.phone = request.getPhone();
         this.role = Role.fromString(null);
+        this.setCreateBy(request.getUserId());
     }
 
     public User(String userId) {


### PR DESCRIPTION
-UserAuditorAware 걷어냄
-비효율적이라 판단
-회원가입시 dto에서 입력받은 값으로 createby를 해줘야 하는데, UserAuditorAware를 사용하여 구현하면 특수 케이스가 전역에 걸쳐 영향도가 높아진다 판단하여 제거